### PR TITLE
Disable adding a record from hooking loop

### DIFF
--- a/map/MediaHooker.swift
+++ b/map/MediaHooker.swift
@@ -29,14 +29,15 @@ class MediaHooker {
         // TODO: DEBUG
         let hookedData = self.hookMedia()
         
-        sleep(5)
+        sleep(3600)
         DispatchQueue.main.async {
             print("hooked: \(self.count)")
         }
         
         self.count += 1
         
-        Monitor.shared.hooked(media: hookedData)
+        // Disable for testing in actual trip
+        //Monitor.shared.hooked(media: hookedData)
     }
     
     func startHooking() {


### PR DESCRIPTION
Temporary disabled adding a dump record from the hooking loop.
And now hooking message is saved for every hour.